### PR TITLE
nimph/config: find the compiler at runtime

### DIFF
--- a/src/nimph/config.nim
+++ b/src/nimph/config.nim
@@ -103,7 +103,7 @@ proc loadAllCfgs*(directory: string): ConfigRef =
 
   # stuff the prefixDir so we load the compiler's config/nim.cfg
   # just like the compiler would if we were to invoke it directly
-  let compiler = getCurrentCompilerExe()
+  let compiler = findExe("nim")
   result.prefixDir = AbsoluteDir splitPath(compiler.parentDir).head
 
   withinDirectory(directory):


### PR DESCRIPTION
As some search paths are derived from the compiler location, storing the
compiler location at compile time will cause it to not work if the
real compiler is not the same as the one used to compile nimph.

This patch make nimph look for the compiler in PATH instead.

Fixes #118 