### PR TITLE
Handle most types of git remote urls

### DIFF
--- a/src/nimph/project.nim
+++ b/src/nimph/project.nim
@@ -558,7 +558,7 @@ proc findRepositoryUrl*(project: Project; name = defaultRemote): Option[Uri] =
         free remote.get
 
       try:
-        let url = remote.get.url
+        let url = remote.get.url.normalizeUrl
         if url.isValid:
           # this is our only success scenario
           result = url.some

--- a/tests/tspec.nim
+++ b/tests/tspec.nim
@@ -29,6 +29,25 @@ suite "spec":
       check fork.ok
       check fork.owner == "disruptek" and fork.repo == "nimph"
 
+  test "url normalization":
+    let
+      sshUser = "git"
+      sshUrl1 = "git@git.sr.ht:~kungtotte/dtt"
+      sshHost1 = "git.sr.ht"
+      sshPath1 = "~kungtotte/dtt"
+      sshUrl2 = "git@github.com:disruptek/nimph.git"
+      sshHost2 = "github.com"
+      sshPath2 = "disruptek/nimph.git"
+      normUrl1 = normalizeUrl(parseUri(sshUrl1))
+      normUrl2 = normalizeUrl(parseUri(sshUrl2))
+
+    check normUrl1.username == sshUser
+    check normUrl1.hostname == sshHost1
+    check normUrl1.path == sshPath1
+    check normUrl2.username == sshUser
+    check normUrl2.hostname == sshHost2
+    check normUrl2.path == sshPath2
+
   test "path joins":
     let
       p = "goats"


### PR DESCRIPTION
The old behaviour of url normalization depended a lot on the specifics
of GitHub urls, which made it error out on other source forge urls
(particularly sourcehut in my case).

This code makes fewer assumptions about how your urls are formatted and
picks apart the relevant sections of the url and uses those for the uri
pieces. It still can't handle -every- possible corner case, but it ought
to deal with most sane urls.